### PR TITLE
Fix array value constructors so they return the correct type.

### DIFF
--- a/src/ansys/common/variableinterop/array_values.py
+++ b/src/ansys/common/variableinterop/array_values.py
@@ -16,9 +16,9 @@ from ansys.common.variableinterop.scalar_values import (
     RealValue,
     StringValue,
 )
-from ansys.common.variableinterop.utils.string_escaping import escape_string, unescape_string
 from ansys.common.variableinterop.utils.array_to_from_string_util import ArrayToFromStringUtil
 from ansys.common.variableinterop.utils.locale_utils import LocaleUtils
+from ansys.common.variableinterop.utils.string_escaping import escape_string, unescape_string
 import ansys.common.variableinterop.variable_type as variable_type
 
 from .variable_value import CommonArrayValue
@@ -39,9 +39,9 @@ class BooleanArrayValue(CommonArrayValue[np.bool_]):
         if values is not None:
             return np.array(values, dtype=np.bool_).view(cls)
         elif shape_ is not None:
-            return super().__new__(cls, shape=shape_, dtype=np.bool_)
+            return super().__new__(cls, shape=shape_, dtype=np.bool_).view(cls)
         else:
-            return np.zeros(shape=(), dtype=np.bool_)
+            return np.zeros(shape=(), dtype=np.bool_).view(cls)
 
     @overrides
     def __eq__(self, other) -> bool:
@@ -121,9 +121,9 @@ class IntegerArrayValue(CommonArrayValue[np.int64]):
         if values is not None:
             return np.array(values, dtype=np.int64).view(cls)
         elif shape_ is not None:
-            return super().__new__(cls, shape=shape_, dtype=np.int64)
+            return super().__new__(cls, shape=shape_, dtype=np.int64).view(cls)
         else:
-            return np.zeros(shape=(), dtype=np.int64)
+            return np.zeros(shape=(), dtype=np.int64).view(cls)
 
     @overrides
     def __eq__(self, other):
@@ -201,9 +201,9 @@ class RealArrayValue(CommonArrayValue[np.float64]):
         if values is not None:
             return np.array(values, dtype=np.float64).view(cls)
         elif shape_ is not None:
-            return super().__new__(cls, shape=shape_, dtype=np.float64)
+            return super().__new__(cls, shape=shape_, dtype=np.float64).view(cls)
         else:
-            return np.zeros(shape=(), dtype=np.float64)
+            return np.zeros(shape=(), dtype=np.float64).view(cls)
 
     @overrides
     def __eq__(self, other: RealArrayValue) -> bool:
@@ -296,9 +296,9 @@ class StringArrayValue(CommonArrayValue[np.str_]):
         if values is not None:
             return np.array(values, dtype=np.str_).view(cls)
         elif shape_ is not None:
-            return super().__new__(cls, shape=shape_, dtype=np.str_)
+            return super().__new__(cls, shape=shape_, dtype=np.str_).view(cls)
         else:
-            return np.zeros(shape=(), dtype=np.str_)
+            return np.zeros(shape=(), dtype=np.str_).view(cls)
 
     def __eq__(self, other):
         return np.array_equal(self, other)

--- a/src/ansys/common/variableinterop/file_array_value.py
+++ b/src/ansys/common/variableinterop/file_array_value.py
@@ -32,7 +32,7 @@ class FileArrayValue(variable_value.CommonArrayValue[file_value.FileValue]):
     def __new__(cls, shape_: ArrayLike = None, values: ArrayLike = None):
         if values:
             return np.array(values, dtype=file_value.FileValue).view(cls)
-        return super().__new__(cls, shape=shape_, dtype=file_value.FileValue)
+        return super().__new__(cls, shape=shape_, dtype=file_value.FileValue).view(cls)
 
     @overrides
     def __eq__(self, other):

--- a/tests/test_boolean_array.py
+++ b/tests/test_boolean_array.py
@@ -5,6 +5,20 @@ import pytest
 from ansys.common.variableinterop.array_values import BooleanArrayValue
 
 
+def test_default_construct() -> None:
+    result = BooleanArrayValue()
+
+    assert type(result) is BooleanArrayValue
+    assert numpy.shape(result) == ()
+
+
+def test_shape_construct() -> None:
+    result = BooleanArrayValue(shape_=(2, 4, 9))
+
+    assert type(result) is BooleanArrayValue
+    assert numpy.shape(result) == (2, 4, 9)
+
+
 # @pytest.mark.skip('bool array nditer returning array of bool instead of a bool for each element')
 @pytest.mark.parametrize(
     'source,expected_result',

--- a/tests/test_file_array_value.py
+++ b/tests/test_file_array_value.py
@@ -1,8 +1,23 @@
 from pathlib import Path
 
+import numpy
 from test_file_value import _TestFileValue
 
 import ansys.common.variableinterop as acvi
+
+
+def test_default_construct() -> None:
+    result = acvi.FileArrayValue()
+
+    assert type(result) is acvi.FileArrayValue
+    assert numpy.shape(result) == ()
+
+
+def test_shape_construct() -> None:
+    result = acvi.FileArrayValue(shape_=(2, 4, 9))
+
+    assert type(result) is acvi.FileArrayValue
+    assert numpy.shape(result) == (2, 4, 9)
 
 
 def test_construct_1d():

--- a/tests/test_integer_array_value.py
+++ b/tests/test_integer_array_value.py
@@ -5,6 +5,20 @@ import pytest
 from ansys.common.variableinterop import IntegerArrayValue
 
 
+def test_default_construct() -> None:
+    result = IntegerArrayValue()
+
+    assert type(result) is IntegerArrayValue
+    assert numpy.shape(result) == ()
+
+
+def test_shape_construct() -> None:
+    result = IntegerArrayValue(shape_=(2, 4, 9))
+
+    assert type(result) is IntegerArrayValue
+    assert numpy.shape(result) == (2, 4, 9)
+
+
 @pytest.mark.parametrize(
     'source,expected_result',
     [

--- a/tests/test_real_array_value.py
+++ b/tests/test_real_array_value.py
@@ -5,6 +5,19 @@ import pytest
 from ansys.common.variableinterop import RealArrayValue
 
 
+def test_default_construct() -> None:
+    result = RealArrayValue()
+
+    assert type(result) is RealArrayValue
+    assert numpy.shape(result) == ()
+
+
+def test_shape_construct() -> None:
+    result = RealArrayValue(shape_=(2, 4, 9))
+
+    assert type(result) is RealArrayValue
+    assert numpy.shape(result) == (2, 4, 9)
+
 @pytest.mark.parametrize(
     'source,expected_result',
     [

--- a/tests/test_string_array_value.py
+++ b/tests/test_string_array_value.py
@@ -5,6 +5,20 @@ import pytest
 from ansys.common.variableinterop import StringArrayValue
 
 
+def test_default_construct() -> None:
+    result = StringArrayValue()
+
+    assert type(result) is StringArrayValue
+    assert numpy.shape(result) == ()
+
+
+def test_shape_construct() -> None:
+    result = StringArrayValue(shape_=(2, 4, 9))
+
+    assert type(result) is StringArrayValue
+    assert numpy.shape(result) == (2, 4, 9)
+
+
 @pytest.mark.parametrize(
     'source,expected_result',
     [


### PR DESCRIPTION
Currently, array value constructors do not actually return instances of the specified type if no value array is specified. This PR resolves the issue.