### PR TITLE
GitHub button link is broken

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,7 +17,7 @@ html_theme = "pyansys_sphinx_theme"
 
 # specify the location of your github repo
 html_theme_options = {
-    "github_url": "https://github.com/pyansys/pyansys-sphinx-theme",
+    "github_url": "https://github.com/pyansys/ansys-common-variableinterop",
     "show_prev_next": False,
 }
 


### PR DESCRIPTION
As title says. If you click on it, you are redirected to the ``ansys-sphinx-theme`` repo.