### PR TITLE
fix: bug with python 3.12

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   DOCUMENTATION_CNAME: 'variableinterop.docs.pyansys.com'
-  MAIN_PYTHON_VERSION: '3.12' # for testing purposes
+  MAIN_PYTHON_VERSION: '3.10'
   PACKAGE_NAME: 'pyansys-tools-variableinterop'
 
 jobs:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   DOCUMENTATION_CNAME: 'variableinterop.docs.pyansys.com'
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.12' # for testing purposes
   PACKAGE_NAME: 'pyansys-tools-variableinterop'
 
 jobs:

--- a/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
+++ b/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
@@ -22,7 +22,6 @@
 """Defines the ``FromFormattedStringVisitor`` class."""
 from __future__ import annotations
 
-import distutils.util
 import locale
 
 import numpy as np
@@ -35,6 +34,22 @@ from .scalar_values import BooleanValue, IntegerValue, RealValue, StringValue
 from .utils.array_to_from_string_util import ArrayToFromStringUtil
 from .utils.locale_utils import LocaleUtils
 from .variable_value import IVariableValue
+
+
+def strtobool(val):
+    """
+    Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values are 'n', 'no',
+    'f', 'false', 'off', and '0'.  Raises ValueError if 'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
@@ -68,7 +83,7 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
     @overrides
     def visit_boolean(self) -> BooleanValue:
         result: np.str_ = LocaleUtils.perform_safe_locale_action(
-            self._locale_name, lambda: bool(distutils.util.strtobool(self._value))
+            self._locale_name, lambda: bool(strtobool(self._value))
         )
         return result
 


### PR DESCRIPTION
The `distutils` library has been deprecated for Python 3.12. As it was a Python core library, it is not possible to reinstall it.
This error has been fixed by adding an equivalent function at the `distutils.util.strtobool` one.