### PR TITLE
Fix doc-deploy-dev permissions for gh-pages doc pushes

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -185,6 +185,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [package]
+    permissions:
+      contents: write # Needed to push built docs to gh-pages during dev deploy
     steps:
       - name: "Deploy the latest documentation"
         uses: ansys/actions/doc-deploy-dev@41f86da4c9ead510db9135e428e33df9cc6f92e1 # v10.2.3


### PR DESCRIPTION
Adding write permissions for doc push.

https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_sprints/taskboard/ModelCenter%20-%20Corsair/Portfolio/2025-PI-2/2025-IT-16?workitem=1384731