### PR TITLE
 Fixed FromFormattedStringVisitor returning base objects instead of IVariableValues.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   - id: flake8
 
 - repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.5
+  rev: v1.7.7
   hooks:
   - id: docformatter
     additional_dependencies: [tomli]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/ansys/tools/variableinterop/__init__.py
+++ b/src/ansys/tools/variableinterop/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/api_serialization.py
+++ b/src/ansys/tools/variableinterop/api_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/api_string_to_value_visitor.py
+++ b/src/ansys/tools/variableinterop/api_string_to_value_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/array_metadata.py
+++ b/src/ansys/tools/variableinterop/array_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/array_value_conversion.py
+++ b/src/ansys/tools/variableinterop/array_value_conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/array_values.py
+++ b/src/ansys/tools/variableinterop/array_values.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/common_variable_metadata.py
+++ b/src/ansys/tools/variableinterop/common_variable_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/exceptions.py
+++ b/src/ansys/tools/variableinterop/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/file_array_metadata.py
+++ b/src/ansys/tools/variableinterop/file_array_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/file_array_value.py
+++ b/src/ansys/tools/variableinterop/file_array_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/file_metadata.py
+++ b/src/ansys/tools/variableinterop/file_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/file_scope.py
+++ b/src/ansys/tools/variableinterop/file_scope.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/file_value.py
+++ b/src/ansys/tools/variableinterop/file_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
+++ b/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
+++ b/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
@@ -27,9 +27,10 @@ import locale
 import numpy as np
 from overrides import overrides
 
-from . import FileArrayValue, FileValue
 from .array_values import BooleanArrayValue, IntegerArrayValue, RealArrayValue, StringArrayValue
 from .exceptions import ValueDeserializationUnsupportedException, _error
+from .file_value import FileValue
+from .file_array_value import FileArrayValue
 from .ivariable_type_pseudovisitor import IVariableTypePseudoVisitor
 from .scalar_values import BooleanValue, IntegerValue, RealValue, StringValue
 from .utils.array_to_from_string_util import ArrayToFromStringUtil

--- a/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
+++ b/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
@@ -27,6 +27,7 @@ import locale
 import numpy as np
 from overrides import overrides
 
+from . import FileArrayValue, FileValue
 from .array_values import BooleanArrayValue, IntegerArrayValue, RealArrayValue, StringArrayValue
 from .exceptions import ValueDeserializationUnsupportedException, _error
 from .ivariable_type_pseudovisitor import IVariableTypePseudoVisitor
@@ -71,32 +72,32 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
         result: IntegerValue = LocaleUtils.perform_safe_locale_action(
             self._locale_name, lambda: np.int64(locale.atof(self._value))
         )
-        return result
+        return IntegerValue(result)
 
     @overrides
     def visit_real(self) -> RealValue:
         result: np.str_ = LocaleUtils.perform_safe_locale_action(
             self._locale_name, lambda: locale.atof(self._value)
         )
-        return result
+        return RealValue(result)
 
     @overrides
     def visit_boolean(self) -> BooleanValue:
         result: np.str_ = LocaleUtils.perform_safe_locale_action(
             self._locale_name, lambda: bool(strtobool(self._value))
         )
-        return result
+        return BooleanValue(result)
 
     @overrides
     def visit_string(self) -> StringValue:
-        return self._value
+        return StringValue(self._value)
 
     @overrides
-    def visit_file(self) -> IVariableValue:
+    def visit_file(self) -> FileValue:
         raise ValueDeserializationUnsupportedException(_error("ERROR_FILE_FROM_DISPLAY_STR"))
 
     @overrides
-    def visit_int_array(self) -> IVariableValue:
+    def visit_int_array(self) -> IntegerArrayValue:
         return ArrayToFromStringUtil.string_to_value(
             self._value,
             lambda val: IntegerArrayValue(values=val),
@@ -104,7 +105,7 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
         )
 
     @overrides
-    def visit_real_array(self) -> IVariableValue:
+    def visit_real_array(self) -> RealArrayValue:
         return ArrayToFromStringUtil.string_to_value(
             self._value,
             lambda val: RealArrayValue(values=val),
@@ -112,7 +113,7 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
         )
 
     @overrides
-    def visit_bool_array(self) -> IVariableValue:
+    def visit_bool_array(self) -> BooleanArrayValue:
         return ArrayToFromStringUtil.string_to_value(
             self._value,
             lambda val: BooleanArrayValue(values=val),
@@ -120,7 +121,7 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
         )
 
     @overrides
-    def visit_string_array(self) -> IVariableValue:
+    def visit_string_array(self) -> StringArrayValue:
         return ArrayToFromStringUtil.string_to_value(
             self._value,
             lambda val: StringArrayValue(values=val),
@@ -128,5 +129,5 @@ class FromFormattedStringVisitor(IVariableTypePseudoVisitor[IVariableValue]):
         )
 
     @overrides
-    def visit_file_array(self) -> IVariableValue:
+    def visit_file_array(self) -> FileArrayValue:
         raise ValueDeserializationUnsupportedException(_error("ERROR_FILE_FROM_DISPLAY_STR"))

--- a/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
+++ b/src/ansys/tools/variableinterop/from_formatted_string_visitor.py
@@ -29,8 +29,8 @@ from overrides import overrides
 
 from .array_values import BooleanArrayValue, IntegerArrayValue, RealArrayValue, StringArrayValue
 from .exceptions import ValueDeserializationUnsupportedException, _error
-from .file_value import FileValue
 from .file_array_value import FileArrayValue
+from .file_value import FileValue
 from .ivariable_type_pseudovisitor import IVariableTypePseudoVisitor
 from .scalar_values import BooleanValue, IntegerValue, RealValue, StringValue
 from .utils.array_to_from_string_util import ArrayToFromStringUtil

--- a/src/ansys/tools/variableinterop/isave_context.py
+++ b/src/ansys/tools/variableinterop/isave_context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/ivariable_type_pseudovisitor.py
+++ b/src/ansys/tools/variableinterop/ivariable_type_pseudovisitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/ivariable_visitor.py
+++ b/src/ansys/tools/variableinterop/ivariable_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/ivariablemetadata_visitor.py
+++ b/src/ansys/tools/variableinterop/ivariablemetadata_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/non_managing_file_scope.py
+++ b/src/ansys/tools/variableinterop/non_managing_file_scope.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/numeric_metadata.py
+++ b/src/ansys/tools/variableinterop/numeric_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/scalar_metadata.py
+++ b/src/ansys/tools/variableinterop/scalar_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/scalar_value_conversion.py
+++ b/src/ansys/tools/variableinterop/scalar_value_conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/scalar_values.py
+++ b/src/ansys/tools/variableinterop/scalar_values.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/scalar_values.py
+++ b/src/ansys/tools/variableinterop/scalar_values.py
@@ -600,6 +600,10 @@ class StringValue(np.str_, IVariableValue):
     naturally to the analogous NumPy type.
     """
 
+    def __init__(self, value=..., /):
+        # Need to override init to make this not abstract, but np.str_ objects are immutable.
+        pass
+
     @overrides
     def accept(self, visitor: IVariableValueVisitor[T]) -> T:
         return visitor.visit_string(self)

--- a/src/ansys/tools/variableinterop/utils/__init__.py
+++ b/src/ansys/tools/variableinterop/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/utils/array_to_from_string_util.py
+++ b/src/ansys/tools/variableinterop/utils/array_to_from_string_util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/utils/implicit_coercion.py
+++ b/src/ansys/tools/variableinterop/utils/implicit_coercion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/utils/locale_utils.py
+++ b/src/ansys/tools/variableinterop/utils/locale_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/utils/string_escaping.py
+++ b/src/ansys/tools/variableinterop/utils/string_escaping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/utils/variable_type_util.py
+++ b/src/ansys/tools/variableinterop/utils/variable_type_util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/value_from_formatted_string.py
+++ b/src/ansys/tools/variableinterop/value_from_formatted_string.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/var_type_array_check.py
+++ b/src/ansys/tools/variableinterop/var_type_array_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/variable_state.py
+++ b/src/ansys/tools/variableinterop/variable_state.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/variable_type.py
+++ b/src/ansys/tools/variableinterop/variable_type.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/variable_value.py
+++ b/src/ansys/tools/variableinterop/variable_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/variableinterop/vartype_arrays_and_elements.py
+++ b/src/ansys/tools/variableinterop/vartype_arrays_and_elements.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_array_value_conversion.py
+++ b/tests/test_array_value_conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_boolean_array.py
+++ b/tests/test_boolean_array.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_boolean_value.py
+++ b/tests/test_boolean_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_common_variable_metadata.py
+++ b/tests/test_common_variable_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_file_array_value.py
+++ b/tests/test_file_array_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_file_value.py
+++ b/tests/test_file_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_from_api_string.py
+++ b/tests/test_from_api_string.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_from_formatted_string_visitor.py
+++ b/tests/test_from_formatted_string_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_from_formatted_string_visitor.py
+++ b/tests/test_from_formatted_string_visitor.py
@@ -78,6 +78,7 @@ def test_converting_from_an_integer(value: str, locale_value: str, expected: Int
 
     # Verification
     assert result == expected
+    assert isinstance(result, IntegerValue)
 
 
 @pytest.mark.parametrize(
@@ -153,6 +154,7 @@ def test_converting_from_a_real(value: str, locale_value: str, expected: RealVal
         assert np.isnan(result)
     else:
         assert result == expected
+    assert isinstance(result, RealValue)
 
 
 @pytest.mark.parametrize(
@@ -194,6 +196,7 @@ def test_converting_from_a_boolean(value: str, locale_value: str, expected: Bool
 
     # Verification
     assert result == expected
+    assert isinstance(result, BooleanValue)
 
 
 @pytest.mark.parametrize(
@@ -247,6 +250,7 @@ def test_converting_from_a_string(value: str, locale_value: str, expected: Strin
 
     # Verification
     assert result == expected
+    assert isinstance(result, StringValue)
 
 
 @pytest.mark.parametrize(
@@ -292,6 +296,7 @@ def test_converting_from_an_integer_array(
 
     # Verification
     assert np.array_equal(result, expected)
+    assert isinstance(result, IntegerArrayValue)
 
 
 @pytest.mark.parametrize(
@@ -340,6 +345,7 @@ def test_converting_from_a_real_array(
 
     # Verification
     assert np.array_equal(result, expected)
+    assert isinstance(result, RealArrayValue)
 
 
 @pytest.mark.parametrize(
@@ -395,6 +401,7 @@ def test_converting_from_a_boolean_array(
 
     # Verification
     assert np.array_equal(result, expected)
+    assert isinstance(result, BooleanArrayValue)
 
 
 @pytest.mark.parametrize(
@@ -446,6 +453,7 @@ def test_converting_from_a_string_array(
 
     # Verification
     assert np.array_equal(result, expected)
+    assert isinstance(result, StringArrayValue)
 
 
 def test_converting_file_value():

--- a/tests/test_implicit_coercion.py
+++ b/tests/test_implicit_coercion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_integer_array_value.py
+++ b/tests/test_integer_array_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_integer_value.py
+++ b/tests/test_integer_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_metadata_visitor.py
+++ b/tests/test_metadata_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_non_managing_file_scope.py
+++ b/tests/test_non_managing_file_scope.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_real_array_value.py
+++ b/tests/test_real_array_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_real_value.py
+++ b/tests/test_real_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_scalar_value_conversion.py
+++ b/tests/test_scalar_value_conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_string_array_value.py
+++ b/tests/test_string_array_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_string_escaping.py
+++ b/tests/test_string_escaping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_string_value.py
+++ b/tests/test_string_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_to_display_string.py
+++ b/tests/test_to_display_string.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_var_type_is_array.py
+++ b/tests/test_var_type_is_array.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_variable_type.py
+++ b/tests/test_variable_type.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_variable_value.py
+++ b/tests/test_variable_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_vartype_arrays_and_elements.py
+++ b/tests/test_vartype_arrays_and_elements.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_vartype_constructmetadata.py
+++ b/tests/test_vartype_constructmetadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_vartype_defaultvalue.py
+++ b/tests/test_vartype_defaultvalue.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/variable_type_pseudovisitor_test.py
+++ b/tests/variable_type_pseudovisitor_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #


### PR DESCRIPTION
Also fixed StringValue showing up as abstract in type checkers due to missing __init__ implementation.

Resolves #205 